### PR TITLE
Default to rails 3.1 railtie deprecation: config.app_generators

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -4,10 +4,10 @@ require 'slim'
 module Slim
   module Rails
     class Railtie < ::Rails::Railtie
-      unless ::Rails.version =~ /$3.1/
-        config.generators.template_engine :slim
-      else
+      begin
         config.app_generators.template_engine :slim
+      rescue
+        config.generators.template_engine :slim
       end
     end
   end


### PR DESCRIPTION
Default to rails 3.1 railtie deprecation: config.app_generators falls back to config.generators. Fixes NoMethodError: undefined method `generators' in Rails 3.2.1.
