### PR TITLE
Rails 3.2 compatibility

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -4,9 +4,9 @@ require 'slim'
 module Slim
   module Rails
     class Railtie < ::Rails::Railtie
-      unless ::Rails.version =~ /$3.1/
+      if config.respond_to?(:generators)
         config.generators.template_engine :slim
-      else
+      elsif config.respond_to?(:app_generators)
         config.app_generators.template_engine :slim
       end
     end


### PR DESCRIPTION
When upgrading to version 1.0.0 slim-rails stop working on a rails 3.2.1 application, here's the backtrace:

<pre>
isis:ohhgabriel wedcompany[feature/rails-3.2]$ rake spec --trace
DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from require at /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:68)
rake aborted!
undefined method `generators' for #<Rails::Railtie::Configuration:0x007fc4f664e5c0>
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/railties-3.2.1/lib/rails/railtie/configuration.rb:85:in `method_missing'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/slim-rails-1.0.0/lib/slim-rails.rb:8:in `<class:Railtie>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/slim-rails-1.0.0/lib/slim-rails.rb:6:in `<module:Rails>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/slim-rails-1.0.0/lib/slim-rails.rb:5:in `<module:Slim>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/slim-rails-1.0.0/lib/slim-rails.rb:4:in `<top (required)>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in `require'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in `each'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in `block in require'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in `each'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in `require'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.21/lib/bundler.rb:122:in `require'
/Users/ohhgabriel/Workspace/wedcompany/config/application.rb:7:in `<top (required)>'
/Users/ohhgabriel/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/ohhgabriel/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/ohhgabriel/Workspace/wedcompany/Rakefile:4:in `<top (required)>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/rake_module.rb:25:in `load'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/rake_module.rb:25:in `load_rakefile'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:501:in `raw_load_rakefile'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:82:in `block in load_rakefile'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:81:in `load_rakefile'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:65:in `block in run'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/bin/rake:19:in `load'
/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@wedcompany32/bin/rake:19:in `<main>'
</pre>


Also, I wasn't able to run the tests:

<pre>
isis:ohhgabriel slim-rails[rails-3.2]$ bundle exec rake
/Users/ohhgabriel/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -I"lib:lib:test" -I"/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib" "/Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" 
/Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:61:in `require': cannot load such file -- rails/generators/mailer/mailer_generator (LoadError)
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:61:in `block (2 levels) in require_generators'
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:59:in `each'
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:59:in `block in require_generators'
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:58:in `each'
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:58:in `require_generators'
    from /Users/ohhgabriel/Workspace/slim-rails/test/test_helper.rb:70:in `<top (required)>'
    from /Users/ohhgabriel/Workspace/slim-rails/test/lib/generators/slim/controller_generator_test.rb:1:in `require'
    from /Users/ohhgabriel/Workspace/slim-rails/test/lib/generators/slim/controller_generator_test.rb:1:in `<top (required)>'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:10:in `require'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:9:in `each'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:9:in `block in <main>'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/ohhgabriel/.rvm/gems/ruby-1.9.3-p0@slim-rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [/Users/ohhgabriel/.rvm/rubies/ruby-1.9.3-p...]

Tasks: TOP => default => test
(See full trace by running task with --trace)
</pre>
