### PR TITLE
Fixed File.join errors in scaffold_generator.rb

### DIFF
--- a/lib/generators/slim/scaffold/scaffold_generator.rb
+++ b/lib/generators/slim/scaffold/scaffold_generator.rb
@@ -3,12 +3,12 @@ require 'rails/generators/erb/scaffold/scaffold_generator'
 module Slim
   module Generators
     class ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
-      source_root File.expand_path File.join '..', templates, __FILE__
+      source_root File.expand_path File.join('..', 'templates'), __FILE__
 
       def copy_view_files
         available_views.each do |view|
           filename = filename_with_extensions view
-          template "#{view}.html.slim", File.join 'app', 'views', controller_file_path, filename
+          template "#{view}.html.slim", File.join('app', 'views', controller_file_path, filename)
         end
       end
 


### PR DESCRIPTION
Fixed file.join errors in scaffold_generator.rb. It was having problems generating templates in some cases.
