### PR TITLE
changed :confirm => 'Text' to :data => {:confirm => 'Text'} 

### DIFF
--- a/lib/generators/slim/scaffold/templates/index.html.slim
+++ b/lib/generators/slim/scaffold/templates/index.html.slim
@@ -16,7 +16,7 @@ table
 <% end -%>
       td = link_to 'Show', <%= singular_table_name %>
       td = link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-      td = link_to 'Destroy', <%= singular_table_name %>, :confirm => 'Are you sure?', :method => :delete
+      td = link_to 'Destroy', <%= singular_table_name %>, :data => {:confirm => 'Are you sure?'}, :method => :delete
 
 br
 


### PR DESCRIPTION
Avoids Rails 4 deprecation warning.  This format has been acceptable since Rails 3.1. I believe.
