### PR TITLE
Get scaffold generator working for rails 4.1

### DIFF
--- a/lib/generators/slim/scaffold/scaffold_generator.rb
+++ b/lib/generators/slim/scaffold/scaffold_generator.rb
@@ -7,7 +7,7 @@ module Slim
 
       def copy_view_files
         available_views.each do |view|
-          filename = filename_with_extensions view
+          filename = filename_with_extensions view, :html
           template "#{view}.html.slim", File.join('app', 'views', controller_file_path, filename)
         end
       end


### PR DESCRIPTION
filename_with_extensions default to :html (2 arguments are currently required instead of the single)
