### PR TITLE
Add rails 4 support

### DIFF
--- a/lib/generators/slim/scaffold/scaffold_generator.rb
+++ b/lib/generators/slim/scaffold/scaffold_generator.rb
@@ -7,7 +7,13 @@ module Slim
 
       def copy_view_files
         available_views.each do |view|
-          filename = filename_with_extensions view
+          filename = case method(:filename_with_extensions).arity
+            when 2
+              filename_with_extensions view,'html'
+            else
+              filename_with_extensions view
+            end
+
           template "#{view}.html.slim", File.join('app', 'views', controller_file_path, filename)
         end
       end


### PR DESCRIPTION
rails 4 changed the method **filename_with_extensions**  arguments https://github.com/rails/rails/commit/02c814c99202e42ebeb10b89af1392b594c727e9.

Sadly, the  `format`  argument does not have default value :(
