### PR TITLE
Require version specifier file

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -1,3 +1,4 @@
+require 'slim-rails/version'
 require 'rails'
 require 'slim'
 


### PR DESCRIPTION
Requires the slim-rails version file.
It's a best practice to expose library versions to clients by default.
