### PR TITLE
Remove "Save" label from submit button in form partial

### DIFF
--- a/lib/generators/slim/scaffold/templates/_form.html.slim
+++ b/lib/generators/slim/scaffold/templates/_form.html.slim
@@ -11,4 +11,4 @@
     = f.label :<%= attribute.name %>
     = f.<%= attribute.field_type %> :<%= attribute.name %>
 <% end -%>
-  .actions = f.submit 'Save'
+  .actions = f.submit


### PR DESCRIPTION
The [equivalent erb template](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb) doesn't explicitly set the text on the button as it can be generated automatically and [changes depending if the resource is new or existing](http://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-submit) (a bit like the url in `form_for`).
