### PR TITLE
Rails 4.2.0 released, updating dependencies

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard', '~> 2.10'
   gem.add_development_dependency 'guard-minitest', '~> 2.3'
   gem.add_development_dependency 'guard-rocco', ['>= 0.0.3', '< 1.0.0']
-  gem.add_runtime_dependency 'activesupport', ['>= 3.0', '< 4.2']
-  gem.add_runtime_dependency 'actionpack',    ['>= 3.0', '< 4.2']
-  gem.add_runtime_dependency 'actionmailer',  ['>= 3.0', '< 4.2']
-  gem.add_runtime_dependency 'railties',      ['>= 3.0', '< 4.2']
+  gem.add_runtime_dependency 'activesupport', ['>= 3.0', '< 5.0']
+  gem.add_runtime_dependency 'actionpack',    ['>= 3.0', '< 5.0']
+  gem.add_runtime_dependency 'actionmailer',  ['>= 3.0', '< 5.0']
+  gem.add_runtime_dependency 'railties',      ['>= 3.0', '< 5.0']
   gem.add_runtime_dependency 'slim',          '~> 3.0'
 end
 


### PR DESCRIPTION
There will be no more releases till 5.0, so bumping to 5.0

You can take a look at release notes here:
http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/
