### PR TITLE
Add leading and trailing whitespaces

### DIFF
--- a/lib/generators/slim/scaffold/templates/show.html.slim
+++ b/lib/generators/slim/scaffold/templates/show.html.slim
@@ -3,9 +3,9 @@ p#notice = notice
 <% attributes.each do |attribute| -%>
 p
   strong <%= attribute.human_name %>:
-  = @<%= singular_table_name %>.<%= attribute.name %>
+  =< @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
 
-= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+=> link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
 '|
-= link_to 'Back', <%= index_helper %>_path
+=< link_to 'Back', <%= index_helper %>_path


### PR DESCRIPTION
The current scaffold template renders awkwardly since it's missing leading and trailing whitespace in various parts. This aims to clean that up.
