### PR TITLE
Ruby 1.9 hash notation use in generators

### DIFF
--- a/lib/generators/slim/scaffold/templates/index.html.slim
+++ b/lib/generators/slim/scaffold/templates/index.html.slim
@@ -18,7 +18,7 @@ table
 <% end -%>
         td = link_to 'Show', <%= singular_table_name %>
         td = link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-        td = link_to 'Destroy', <%= singular_table_name %>, data: {:confirm => 'Are you sure?'}, :method => :delete
+        td = link_to 'Destroy', <%= singular_table_name %>, data: { confirm: 'Are you sure?' }, method: :delete
 
 br
 


### PR DESCRIPTION
Use Ruby 1.9 hash notation consistently throughout generators