### PR TITLE
Make actionmailer only as a development dependency

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'slim-rails'
   gem.require_paths = ['lib']
   gem.version       = Slim::Rails::VERSION
-  
+
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_development_dependency 'rake', '~> 10.4'
@@ -25,10 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard', '~> 2.10'
   gem.add_development_dependency 'guard-minitest', '~> 2.3'
   gem.add_development_dependency 'guard-rocco', ['>= 0.0.3', '< 1.0.0']
-  gem.add_runtime_dependency 'activesupport', ['>= 3.1', '< 5.0']
-  gem.add_runtime_dependency 'actionpack',    ['>= 3.1', '< 5.0']
-  gem.add_runtime_dependency 'actionmailer',  ['>= 3.1', '< 5.0']
-  gem.add_runtime_dependency 'railties',      ['>= 3.1', '< 5.0']
-  gem.add_runtime_dependency 'slim',          '~> 3.0'
+  gem.add_development_dependency 'actionmailer', ['>= 3.1', '< 5.0']
+  gem.add_runtime_dependency 'actionpack', ['>= 3.1', '< 5.0']
+  gem.add_runtime_dependency 'railties',   ['>= 3.1', '< 5.0']
+  gem.add_runtime_dependency 'slim',       '~> 3.0'
 end
-


### PR DESCRIPTION
There is no reason to have a runtime dependency on `actionmailer` (not each rails app needs it). Also a runtime dependency on `activesupport` is redundant because other Rails gems depend on it.

In future it would be good to have runtime dependencies on `railties` and `actionview` only.