### PR TITLE
feat: remove actionmailer from development dependency

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard', '~> 2.10'
   gem.add_development_dependency 'guard-minitest', '~> 2.3'
   gem.add_development_dependency 'guard-rocco', ['>= 0.0.3', '< 1.0.0']
-  gem.add_development_dependency 'actionmailer', ['>= 3.1', '< 5.0']
   gem.add_runtime_dependency 'actionpack', ['>= 3.1', '< 5.0']
   gem.add_runtime_dependency 'railties',   ['>= 3.1', '< 5.0']
   gem.add_runtime_dependency 'slim',       '~> 3.0'


### PR DESCRIPTION
can't find a reason for this dependency, and it prevents usage of slim-rails with rails 5. 