### PR TITLE
feat: remove limiting development dependency

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -13,8 +13,4 @@ guard 'minitest' do
   # watch(%r|^spec/spec_helper\.rb|)    { "spec" }
 end
 
-guard 'rocco' do
-  watch(%r{^lib/.*\.rb$})
-end
-
 watch(%r|^benchmarks/(.*)\.rb$|)     { |m| eval File.read "benchmarks/#{m[1]}.rb" }

--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -19,12 +19,10 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_development_dependency 'rake', '~> 10.4'
-  gem.add_development_dependency 'rocco', '~> 0.8'
   gem.add_development_dependency 'redcarpet', '~> 3.2'
   gem.add_development_dependency 'awesome_print', '~> 1.2'
   gem.add_development_dependency 'guard', '~> 2.10'
   gem.add_development_dependency 'guard-minitest', '~> 2.3'
-  gem.add_development_dependency 'guard-rocco', ['>= 0.0.3', '< 1.0.0']
   gem.add_development_dependency 'actionmailer', ['>= 3.1', '< 5.0']
   gem.add_runtime_dependency 'actionpack', ['>= 3.1', '< 5.0']
   gem.add_runtime_dependency 'railties',   ['>= 3.1', '< 5.0']


### PR DESCRIPTION
as alternative to limiting usage to ruby 2.0.0, we could remove rocco (mustache) from the development dependancies. 