### PR TITLE
remove cache_template_loading setting by hard code

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -27,7 +27,6 @@ module Slim
                 # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
                 require 'action_view/dependency_tracker'
                 ActionView::DependencyTracker.register_tracker :slim, ActionView::DependencyTracker::ERBTracker
-                ActionView::Base.cache_template_loading = false if ::Rails.env.development?
               end
             rescue
               # likely this version of Rails doesn't support dependency tracking


### PR DESCRIPTION
users can set that in environments/development.rb, so we should not set this by force