### PR TITLE
Only access environment directly in configure block

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -12,8 +12,10 @@ module Slim
       end
 
       initializer 'slim_rails.configure_template_digestor' do |app|
-        if app.assets && app.assets.respond_to?(:register_engine)
-          app.assets.register_engine '.slim', Slim::Template
+        if config.respond_to?(:assets)
+          config.assets.configure do |env|
+            env.assets.register_engine '.slim', Slim::Template
+          enda
         end
 
         ActiveSupport.on_load(:action_view) do


### PR DESCRIPTION
`app.assets` is only available after the initializers run.
Use configure block to ensure run `register_engine` after `app.assets` initialized.