### PR TITLE
Revert "Only access environment directly in configure block"

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -8,10 +8,8 @@ module Slim
       config.app_generators.template_engine :slim
 
       initializer 'slim_rails.configure_template_digestor' do |app|
-        if config.respond_to?(:assets)
-          config.assets.configure do |env|
-            env.assets.register_engine '.slim', Slim::Template
-          enda
+        if app.assets && app.assets.respond_to?(:register_engine)
+          app.assets.register_engine '.slim', Slim::Template
         end
 
         ActiveSupport.on_load(:action_view) do


### PR DESCRIPTION
Reverts slim-template/slim-rails#115

typo