### PR TITLE
make work with sprockets 4

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -30,7 +30,8 @@ module Slim
         config.assets.configure do |env|
           if env.respond_to?(:register_transformer)
             env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
-            env.register_preprocessor 'text/slim', 'text/html', RegisterEngine::Transformer
+            env.register_preprocessor 'text/slim', RegisterEngine::Transformer
+            env.register_preprocessor 'text/html', RegisterEngine::Transformer
           end
 
           if env.respond_to?(:register_engine)


### PR DESCRIPTION
I was trying to use `slim-rails` with `sprockets-4.0.0.beta3`, but I get following error. 

```
ArgumentError: wrong number of arguments (4 for 2..3)
/tmp/build_475685566bf37f049b2a69c336bc3224/y-yagi-todo_minder-5e27b12/vendor/bundle/ruby/2.2.0/gems/sprockets-4.0.0.beta3/lib/sprockets/processing.rb:212:in `register_config_processor'
/tmp/build_475685566bf37f049b2a69c336bc3224/y-yagi-todo_minder-5e27b12/vendor/bundle/ruby/2.2.0/gems/sprockets-4.0.0.beta3/lib/sprockets/processing.rb:54:in `register_preprocessor'
/tmp/build_475685566bf37f049b2a69c336bc3224/y-yagi-todo_minder-5e27b12/vendor/bundle/ruby/2.2.0/gems/slim-rails-3.1.1/lib/slim-rails/register_engine.rb:33:in `block in _register_engine'
``` 

As far as code, it does not seem to pass Array to `register_preprocessor`.
https://github.com/rails/sprockets/blob/master/lib/sprockets/processing.rb#L53..L54 
https://github.com/rails/sprockets/blob/master/lib/sprockets/processing.rb#L212
