### PR TITLE
Don't register_engine with sprockets > 3.0

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -32,9 +32,7 @@ module Slim
             env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
             env.register_preprocessor 'text/slim', RegisterEngine::Transformer
             env.register_preprocessor 'text/html', RegisterEngine::Transformer
-          end
-
-          if env.respond_to?(:register_engine)
+          elsif env.respond_to?(:register_engine)
             args = ['.slim', Slim::Template]
             args << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
             env.register_engine(*args)


### PR DESCRIPTION
Hi!

I've noticed that memory footprint greatly increased after updating to 3.1.1. I've found that it related to `Sprockets.register_engine` and opened issue there https://github.com/rails/sprockets/issues/432. But there is no much activity.

I'm not sure if `register_engine` is needed for sprockets > 3.0. It's even deprecated. My question left unanswered in that ticket. However, I think we can avoid this call, because before https://github.com/slim-template/slim-rails/commit/bd0b5c944c6c296b3740db040d91ab22565d625b it was not called at all.