### PR TITLE
Bump ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ before_install:
   - gem install bundler
 rvm:
   - ruby-head
-  - 2.3.3
-  - 2.2.6
+  - 2.4
+  - 2.3
+  - 2.2
   - 2.1
   - 2.0
 gemfile:


### PR DESCRIPTION
Include Ruby 2.4 and relax Ruby 2.2/2.3 so rvm just uses latest