### PR TITLE
Enable asset helpers in precompiled templates 

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -3,7 +3,8 @@ module Slim
     module RegisterEngine
       class Transformer
         def self.call(input)
-          Slim::Template.new(input[:name]) { input[:data] }.render(nil)
+          context = input[:environment].context_class.new(input)
+          Slim::Template.new(input[:name]) { input[:data] }.render(context)
         end
       end
 

--- a/test/lib/slim-rails_assets_test.rb
+++ b/test/lib/slim-rails_assets_test.rb
@@ -33,6 +33,9 @@ class Slim::Rails::AssetsTest < ActiveSupport::TestCase
       FileUtils.mkdir_p(File.dirname(asset_path))
       File.write(asset_path, ".test\n  | hi")
 
+      asset_path = File.join(dir, 'app', 'assets', 'html', 'test_helpers.slim')
+      File.write(asset_path, '= logical_path')
+
       `BUNDLE_GEMFILE=#{ENV['BUNDLE_GEMFILE']} bundle exec ruby #{app_path}`
     end
   end
@@ -61,5 +64,9 @@ class Slim::Rails::AssetsTest < ActiveSupport::TestCase
     test "should return Slim version when passing '.slim' extension" do
       assert_equal ".test\n  | hi", with_app(true, 'print DummyApp.assets["test.slim"]')
     end
+  end
+
+  test "should work with asset helpers" do
+    assert_equal 'test_helpers', with_app(true, 'print DummyApp.assets["test_helpers", accept: "text/html"]')
   end
 end


### PR DESCRIPTION
Currently, precompiling Slim templates fails due to `undefined local variable or method` error when asset helpers (e.g. `stylesheet_link_tag`) are used in them.
This PR fixes that by passing `Sprockets::Context` object to `Slim::Template#render`.