### PR TITLE
Make it deal with .slim files correctly

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -28,16 +28,13 @@ module Slim
         return unless config.respond_to?(:assets)
 
         config.assets.configure do |env|
-          if env.respond_to?(:register_transformer)
-            env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
-            env.register_preprocessor 'text/slim', RegisterEngine::Transformer
-            env.register_preprocessor 'text/html', RegisterEngine::Transformer
-          end
-
           if env.respond_to?(:register_engine)
             args = ['.slim', Slim::Template]
-            args << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+            args << { silence_deprecation: true } if Sprockets::VERSION.start_with?('3')
             env.register_engine(*args)
+          elsif env.respond_to?(:register_transformer)
+            env.register_mime_type 'text/slim', extensions: ['.slim', '.html.slim']
+            env.register_transformer 'text/slim', 'text/html', RegisterEngine::Transformer
           end
         end
       end

--- a/test/lib/slim-rails_assets_test.rb
+++ b/test/lib/slim-rails_assets_test.rb
@@ -28,6 +28,6 @@ class Slim::Rails::AssetsTest < ActiveSupport::TestCase
 
   test 'compile slim view' do
     assert_equal 'ok', with_app(false, 'print DummyApp.assets || "ok"')
-    assert_equal '<div class="test">hi</div>', with_app(true, 'print DummyApp.assets["test.slim"].to_s')
+    assert_equal '<div class="test">hi</div>', with_app(true, 'print DummyApp.assets["test", accept: "text/html"].to_s')
   end
 end


### PR DESCRIPTION
Currently, this gem can't deal with `.slim` files (inside `app/assets/templates`)  correctly on each version of Sprockets:

* On Sprockets v3: An extension of `.slim` files doesn't change after precompiling, even though each body has been converted into HTML
* On Sprockets v4: `.slim` files aren't precompiled, even though users have added each logical path to `Rails.application.config.assets.precompile`

[NOTE] You can repro the bugs using [this demo app](https://github.com/yasaichi/slim_rails_demo/tree/repro-pulls-136).

I think the expected behavior is as follows:

* On Sprockets v3: `.slim` files are converted into `.html` files by precompiling
* On Sprockets v4: same as v3 when users have added each logical path to the precompile array

As I looked over the code, I found the bugs are caused by using `register_preprocessor` to register `Slim::Rails::RegisterEngine::Transformer` with Sprockets.
This PR fix that by using `register_transformer` instead of the method.
(When you'd like to know further information on the changes, please see [this issue](https://github.com/rails/sprockets/issues/384#issuecomment-247784067).)