### PR TITLE
Add leading and trailing spaces around Show/Edit/Back links in templates

### DIFF
--- a/lib/generators/slim/scaffold/templates/edit.html.slim
+++ b/lib/generators/slim/scaffold/templates/edit.html.slim
@@ -2,7 +2,7 @@ h1 Editing <%= singular_table_name %>
 
 == render 'form'
 
-= link_to 'Show', @<%= singular_table_name %>
+=> link_to 'Show', @<%= singular_table_name %>
 '|
-= link_to 'Back', <%= index_helper %>_path
+=< link_to 'Back', <%= index_helper %>_path
 

--- a/lib/generators/slim/scaffold/templates/show.html.slim
+++ b/lib/generators/slim/scaffold/templates/show.html.slim
@@ -6,6 +6,6 @@ p
   = @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
 
-= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+=> link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
 '|
-= link_to 'Back', <%= index_helper %>_path
+=< link_to 'Back', <%= index_helper %>_path


### PR DESCRIPTION
Based on the work at https://github.com/slim-template/slim-rails/pull/85