### PR TITLE
Use transformer for Sprockets 4+ otherwise fallback to engine

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -28,15 +28,12 @@ module Slim
         return unless config.respond_to?(:assets)
 
         config.assets.configure do |env|
-          if env.respond_to?(:register_transformer)
+          if env.respond_to?(:register_transformer) && Sprockets::VERSION.to_i > 3
             env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
-            env.register_preprocessor 'text/slim', RegisterEngine::Transformer
-            env.register_preprocessor 'text/html', RegisterEngine::Transformer
-          end
-
-          if env.respond_to?(:register_engine)
+            env.register_transformer 'text/slim', 'text/html', RegisterEngine::Transformer
+          elsif env.respond_to?(:register_engine)
             args = ['.slim', Slim::Template]
-            args << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+            args << { silence_deprecation: true } if Sprockets::VERSION.start_with?('3')
             env.register_engine(*args)
           end
         end

--- a/test/lib/slim-rails_assets_test.rb
+++ b/test/lib/slim-rails_assets_test.rb
@@ -29,5 +29,6 @@ class Slim::Rails::AssetsTest < ActiveSupport::TestCase
   test 'compile slim view' do
     assert_equal 'ok', with_app(false, 'print DummyApp.assets || "ok"')
     assert_equal '<div class="test">hi</div>', with_app(true, 'print DummyApp.assets["test.slim"].to_s')
+    assert_equal '<div class="test">hi</div>', with_app(true, 'print DummyApp.assets["test", accept: "text/html"].to_s')
   end
 end


### PR DESCRIPTION
This is an addition to:
https://github.com/slim-template/slim-rails/pull/136
https://github.com/slim-template/slim-rails/pull/132

For Sprockets 3 and 2 we will use `register_engine` , for Sprockets 4 `register_transformer`. 

if we use transformer with Sprockets 3 then Assets Pipeline produces unmodified, fingerprinted files with `.slim` extension (BAD).