### PR TITLE
Update scaffold templates

### DIFF
--- a/lib/generators/slim/scaffold/templates/_form.html.slim
+++ b/lib/generators/slim/scaffold/templates/_form.html.slim
@@ -1,14 +1,29 @@
-= form_for @<%= singular_table_name %> do |f|
-  - if @<%= singular_table_name %>.errors.any?
+<% if Gem::Requirement.new("< 5.1").satisfied_by? Gem::Version.new(Rails::VERSION::STRING) -%>
+= form_for <%= singular_table_name %> do |form|
+<% else -%>
+= form_with(model: <%= singular_table_name %>, local: true) do |form|
+<% end -%>
+  - if <%= singular_table_name %>.errors.any?
     #error_explanation
-      h2 = "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:"
+      h2 = "#{pluralize(<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name.titleize %> from being saved:"
       ul
-        - @<%= singular_table_name %>.errors.full_messages.each do |message|
+        - <%= singular_table_name %>.errors.full_messages.each do |message|
           li = message
 
 <% attributes.each do |attribute| -%>
   .field
-    = f.label :<%= attribute.name %>
-    = f.<%= attribute.field_type %> :<%= attribute.name %>
+<% if attribute.respond_to?(:password_digest?) && attribute.password_digest? -%>
+    = form.label :password
+    = form.password_field :password
+
+  .field
+    = form.label :password_confirmation
+    = form.password_field :password_confirmation
+<% else -%>
+    = form.label :<%= attribute.index_name %>
+    = form.<%= attribute.field_type %> :<%= attribute.index_name %>
 <% end -%>
-  .actions = f.submit
+
+<% end -%>
+  .actions
+    = form.submit

--- a/lib/generators/slim/scaffold/templates/edit.html.slim
+++ b/lib/generators/slim/scaffold/templates/edit.html.slim
@@ -1,8 +1,7 @@
-h1 Editing <%= singular_table_name %>
+h1 Editing <%= singular_table_name.titleize %>
 
-== render 'form'
+= render 'form', <%= singular_table_name %>: @<%= singular_table_name %>
 
-=> link_to 'Show', @<%= singular_table_name %>
-'|
-=< link_to 'Back', <%= index_helper %>_path
-
+= link_to 'Show', @<%= singular_table_name %>
+= " | "
+= link_to 'Back', <%= index_helper %>_path

--- a/lib/generators/slim/scaffold/templates/index.html.slim
+++ b/lib/generators/slim/scaffold/templates/index.html.slim
@@ -1,25 +1,25 @@
-h1 Listing <%= plural_table_name %>
+p#notice = notice
+
+h1 <%= plural_table_name.titleize %>
 
 table
   thead
     tr
-<% attributes.each do |attribute| -%>
+<% attributes.reject{|a| a.respond_to?(:password_digest?) && a.password_digest? }.each do |attribute| -%>
       th <%= attribute.human_name %>
 <% end -%>
-      th
-      th
-      th
+      th colspan="3"
 
   tbody
     - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
       tr
-<% attributes.each do |attribute| -%>
+<% attributes.reject{|a| a.respond_to?(:password_digest?) && a.password_digest? }.each do |attribute| -%>
         td = <%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
         td = link_to 'Show', <%= singular_table_name %>
         td = link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-        td = link_to 'Destroy', <%= singular_table_name %>, data: { confirm: 'Are you sure?' }, method: :delete
+        td = link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }
 
 br
 
-= link_to 'New <%= human_name %>', new_<%= singular_table_name %>_path
+= link_to 'New <%= singular_table_name.titleize %>', new_<%= singular_table_name %>_path

--- a/lib/generators/slim/scaffold/templates/new.html.slim
+++ b/lib/generators/slim/scaffold/templates/new.html.slim
@@ -1,5 +1,5 @@
-h1 New <%= singular_table_name %>
+h1 New <%= singular_table_name.titleize %>
 
-== render 'form'
+= render 'form', <%= singular_table_name %>: @<%= singular_table_name %>
 
 = link_to 'Back', <%= index_helper %>_path

--- a/lib/generators/slim/scaffold/templates/show.html.slim
+++ b/lib/generators/slim/scaffold/templates/show.html.slim
@@ -1,11 +1,11 @@
 p#notice = notice
 
-<% attributes.each do |attribute| -%>
+<% attributes.reject{|a| a.respond_to?(:password_digest?) && a.password_digest? }.each do |attribute| -%>
 p
   strong <%= attribute.human_name %>:
-  = @<%= singular_table_name %>.<%= attribute.name %>
-<% end -%>
+  =< @<%= singular_table_name %>.<%= attribute.name %>
 
-=> link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
-'|
-=< link_to 'Back', <%= index_helper %>_path
+<% end -%>
+= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+= " | "
+= link_to 'Back', <%= index_helper %>_path


### PR DESCRIPTION
All scaffold templates now mirror the current version of their ERB equivalents on Rails master, with the exception of using generator helper methods which do not exist in older version of Rails.  Namely, `model_resource_name`, `singular_route_name`, and `plural_route_name` are currently used by the templates on Rails master, but were only introduced in rails/rails@cf56397, so they are not used here.

The templates on Rails master also now have a `.tt` file extension (rails/rails@8dd76a7), which I think is good practice.  I didn't want to complicate this PR's diff by also renaming the files, but I can submit a follow-up PR to add the `.tt` extension, if desired.

Fixes #160.
