### PR TITLE
Make _register_engine and _register_engine3 private

### DIFF
--- a/lib/slim-rails/register_engine.rb
+++ b/lib/slim-rails/register_engine.rb
@@ -7,34 +7,36 @@ module Slim
         end
       end
 
-      def self.register_engine(app, config)
-        if ::Rails::VERSION::MAJOR == 3
-          _register_engine3(app)
-        else
-          _register_engine(config)
+      class << self
+        def register_engine(app, config)
+          if ::Rails::VERSION::MAJOR == 3
+            _register_engine3(app)
+          else
+            _register_engine(config)
+          end
         end
-      end
 
-      private
+        private
 
-      def self._register_engine3(app)
-        return unless app.assets
-        return unless app.assets.respond_to?(:register_engine)
+        def _register_engine3(app)
+          return unless app.assets
+          return unless app.assets.respond_to?(:register_engine)
 
-        app.assets.register_engine('.slim', Slim::Template)
-      end
+          app.assets.register_engine('.slim', Slim::Template)
+        end
 
-      def self._register_engine(config)
-        return unless config.respond_to?(:assets)
+        def _register_engine(config)
+          return unless config.respond_to?(:assets)
 
-        config.assets.configure do |env|
-          if env.respond_to?(:register_transformer) && Sprockets::VERSION.to_i > 3
-            env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
-            env.register_transformer 'text/slim', 'text/html', RegisterEngine::Transformer
-          elsif env.respond_to?(:register_engine)
-            args = ['.slim', Slim::Template]
-            args << { silence_deprecation: true } if Sprockets::VERSION.start_with?('3')
-            env.register_engine(*args)
+          config.assets.configure do |env|
+            if env.respond_to?(:register_transformer) && Sprockets::VERSION.to_i > 3
+              env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']#, charset: :html
+              env.register_transformer 'text/slim', 'text/html', RegisterEngine::Transformer
+            elsif env.respond_to?(:register_engine)
+              args = ['.slim', Slim::Template]
+              args << { silence_deprecation: true } if Sprockets::VERSION.start_with?('3')
+              env.register_engine(*args)
+            end
           end
         end
       end


### PR DESCRIPTION
`def self.foo` does not define a private method though it is in a private context.
By using `class << self` and `def foo`, we can define a private method on `Slim::Rails::RegisterEngine` module.