### PR TITLE
Relax dependency for slim v4.0.0

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'actionpack', ['>= 3.1']
   spec.add_runtime_dependency 'railties',   ['>= 3.1']
-  spec.add_runtime_dependency 'slim',       ['~> 3.0']
+  spec.add_runtime_dependency 'slim',       ['>= 3.0', '< 5.0']
 
   spec.add_development_dependency 'sprockets-rails'
   spec.add_development_dependency 'rocco'


### PR DESCRIPTION
Now, `slim` v4.0.0 is latest.
https://rubygems.org/gems/slim/versions/4.0.0

I want to use `slim` v4.0.0 via `slim-rails`. 

Gemfile

```ruby
gem "slim", "4.0.0"
gem "slim-rails", "3.1.3"
```

```bash
$ bundle update

(snip)

Bundler could not find compatible versions for gem "slim":
  In Gemfile:
    slim (= 4.0.0)

    slim-rails (= 3.1.3) was resolved to 3.1.3, which depends on
      slim (~> 3.0)
```

So I relaxed dependency.

