### PR TITLE
Bump slim dependency to version 4.0

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'actionpack', ['>= 3.1']
   spec.add_runtime_dependency 'railties',   ['>= 3.1']
-  spec.add_runtime_dependency 'slim',       ['~> 3.0']
+  spec.add_runtime_dependency 'slim',       ['~> 4.0']
 
   spec.add_development_dependency 'sprockets-rails'
   spec.add_development_dependency 'rocco'


### PR DESCRIPTION
Slim 4.0.0 was released on 2018-08-26. 

See: https://github.com/slim-template/slim/blob/master/CHANGES