### PR TITLE
Fix templates to make Slim-Lint happy

### DIFF
--- a/lib/generators/slim/mailer/templates/view.html.slim
+++ b/lib/generators/slim/mailer/templates/view.html.slim
@@ -1,2 +1,2 @@
 h1 <%= class_name %>#<%= @action %>
-p = @greeting + ", find me in <%= @path %>"
+p = "#{@greeting}, find me in <%= @path %>"

--- a/lib/generators/slim/mailer/templates/view.text.slim
+++ b/lib/generators/slim/mailer/templates/view.text.slim
@@ -1,3 +1,3 @@
 ' <%= class_name %>#<%= @action %>
 = "\r\n" * 2
-' #{@greeting + ", find me in <%= @path %>"}
+' #{@greeting}, find me in <%= @path %>

--- a/lib/generators/slim/scaffold/templates/_form.html.slim
+++ b/lib/generators/slim/scaffold/templates/_form.html.slim
@@ -1,7 +1,7 @@
 = form_for @<%= singular_table_name %> do |f|
   - if @<%= singular_table_name %>.errors.any?
     #error_explanation
-      h2 = "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:"
+      h2 = "#{pluralize(@<%= singular_table_name %>.errors.count, 'error')} prohibited this <%= singular_table_name %> from being saved:"
       ul
         - @<%= singular_table_name %>.errors.full_messages.each do |message|
           li = message

--- a/lib/generators/slim/scaffold/templates/edit.html.slim
+++ b/lib/generators/slim/scaffold/templates/edit.html.slim
@@ -5,4 +5,3 @@ h1 Editing <%= singular_table_name %>
 => link_to 'Show', @<%= singular_table_name %>
 '|
 =< link_to 'Back', <%= index_helper %>_path
-

--- a/lib/generators/slim/scaffold/templates/show.html.slim
+++ b/lib/generators/slim/scaffold/templates/show.html.slim
@@ -1,6 +1,6 @@
 p#notice = notice
-
 <% attributes.each do |attribute| -%>
+
 p
   strong <%= attribute.human_name %>:
   = @<%= singular_table_name %>.<%= attribute.name %>

--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'slim',       ['>= 3.0', '< 5.0']
 
   spec.add_development_dependency 'sprockets-rails'
+  spec.add_development_dependency 'slim_lint', '~> 0.21.0'
   spec.add_development_dependency 'rocco'
   spec.add_development_dependency 'redcarpet'
   spec.add_development_dependency 'awesome_print'

--- a/test/lib/generators/slim/controller_generator_test.rb
+++ b/test/lib/generators/slim/controller_generator_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'lib/generators/slim/testing_helper'
 
 class Slim::Generators::ControllerGeneratorTest < Rails::Generators::TestCase
+  include SlimLintHelpers
+
   destination File.join(Rails.root)
   tests Rails::Generators::ControllerGenerator
   arguments %w(Account foo bar --template-engine slim)
@@ -13,5 +15,11 @@ class Slim::Generators::ControllerGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file File.join("app", "views", "account", "foo.html.slim"), %r(app/views/account/foo\.html\.slim)
     assert_file File.join("app", "views", "account", "bar.html.slim"), %r(app/views/account/bar\.html\.slim)
+  end
+
+  test "should generate SlimLint valid templates" do
+    run_generator
+    templates = Dir[File.join(Rails.root, 'app', 'views', '**', '*.slim')]
+    assert_empty lint(templates)
   end
 end

--- a/test/lib/generators/slim/mailer_generator_test.rb
+++ b/test/lib/generators/slim/mailer_generator_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'lib/generators/slim/testing_helper'
 
 class Slim::Generators::MailerGeneratorTest < Rails::Generators::TestCase
+  include SlimLintHelpers
+
   destination File.join(Rails.root)
   tests Rails::Generators::MailerGenerator
   arguments %w(notifier foo bar --template-engine slim)
@@ -17,12 +19,12 @@ class Slim::Generators::MailerGeneratorTest < Rails::Generators::TestCase
     if rails_version >= '5.0'
       assert_file "app/views/notifier_mailer/foo.html.slim" do |view|
         assert_match %r(app/views/notifier_mailer/foo\.html\.slim), view
-        assert_match(/\= @greeting/, view)
+        assert_match(/\#\{@greeting/, view)
       end
 
       assert_file "app/views/notifier_mailer/bar.html.slim" do |view|
         assert_match %r(app/views/notifier_mailer/bar\.html\.slim), view
-        assert_match(/\= @greeting/, view)
+        assert_match(/\#\{@greeting/, view)
       end
 
       assert_file "app/views/notifier_mailer/foo.text.slim" do |view|
@@ -46,12 +48,12 @@ class Slim::Generators::MailerGeneratorTest < Rails::Generators::TestCase
 
         assert_file "app/views/notifier/foo.html.slim" do |view|
           assert_match %r(app/views/notifier/foo\.html\.slim), view
-          assert_match(/\= @greeting/, view)
+          assert_match(/\#\{@greeting/, view)
         end
 
         assert_file "app/views/notifier/bar.html.slim" do |view|
           assert_match %r(app/views/notifier/bar\.html\.slim), view
-          assert_match(/\= @greeting/, view)
+          assert_match(/\#\{@greeting/, view)
         end
 
       end
@@ -66,5 +68,11 @@ class Slim::Generators::MailerGeneratorTest < Rails::Generators::TestCase
         assert_match(/@greeting/, view)
       end
     end
+  end
+
+  test "should generate SlimLint valid templates" do
+    run_generator
+    templates = Dir[File.join(Rails.root, 'app', 'views', '**', '*.slim')]
+    assert_empty lint(templates)
   end
 end

--- a/test/lib/generators/slim/scaffold_generator_test.rb
+++ b/test/lib/generators/slim/scaffold_generator_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'lib/generators/slim/testing_helper'
 
 class Slim::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCase
+  include SlimLintHelpers
+
   destination File.join(Rails.root)
   tests Rails::Generators::ScaffoldGenerator
   arguments %w(product_line title:string price:integer --template-engine slim --orm active-record)
@@ -22,5 +24,11 @@ class Slim::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file File.join "app", "views", "product_lines"
     assert_no_file File.join "app", "views", "layouts", "product_lines.html.slim"
+  end
+
+  test "should generate SlimLint valid templates" do
+    run_generator
+    templates = Dir[File.join(Rails.root, 'app', 'views', '**', '*.slim')]
+    assert_empty lint(templates)
   end
 end

--- a/test/lib/generators/slim/testing_helper.rb
+++ b/test/lib/generators/slim/testing_helper.rb
@@ -1,1 +1,11 @@
+require 'slim_lint'
+
+module SlimLintHelpers
+  EXCLUDED_LINTERS = %w[LineLength]
+
+  def lint(templates)
+    SlimLint::Runner.new.run(files: templates, excluded_linters: EXCLUDED_LINTERS).lints.map(&:message)
+  end
+end
+
 require_generators slim: ['scaffold', 'controller', 'mailer']


### PR DESCRIPTION
Default templates will generate the following errors

```
$ rails g scaffold foo
$ rails g mailer baz
$ rails g controller bar index

$ rails slim_lint
app/views/foos/_form.html.slim:4 [W] RuboCop: Style/StringLiteralsInInterpolation: Prefer single-quoted strings inside interpolations.
app/views/foos/edit.html.slim:8 [W] TrailingBlankLines: Multiple empty lines in the end of file
app/views/foos/show.html.slim:3 [W] EmptyLines: Extra empty line detected
```

~### Could we add slim-lint to this gem to prevent those errors in the future?
I guess we couldn't in an easy way because the templates will generate valid slim files but they are not valid slim files~
