### PR TITLE
Improve Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,45 @@
+dist: focal
+
+os: linux
+
 language: ruby
+
+cache:
+  bundler: true
+
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
+
 rvm:
   - ruby-head
   - 3.0
   - 2.7
   - 2.6
+
 gemfile:
-  - gemfiles/rails_5.gemfile
-  - gemfiles/rails_5.1.gemfile
-  - gemfiles/rails_5.2.gemfile
-  - gemfiles/rails_6.0.gemfile
+  - gemfiles/rails_edge.gemfile
   - gemfiles/rails_6.1.gemfile
-matrix:
+  - gemfiles/rails_6.0.gemfile
+  - gemfiles/rails_5.2.gemfile
+  - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.0.gemfile
+
+jobs:
   allow_failures:
     - rvm: ruby-head
+    - gemfile: gemfiles/rails_edge.gemfile
+
+  exclude:
+    - rvm: 3.0
+      gemfile: gemfiles/rails_5.2.gemfile
     - rvm: 3.0
       gemfile: gemfiles/rails_5.1.gemfile
     - rvm: 3.0
-      gemfile: gemfiles/rails_5.2.gemfile
+      gemfile: gemfiles/rails_5.0.gemfile
+
+  fast_finish: true
+
 addons:
   code_climate:
     repo_token: 294f0ec8183176c0259b75eb21b38414508616985a7b39fc48fec9dfcf40a52e

--- a/Appraisals
+++ b/Appraisals
@@ -1,19 +1,25 @@
-appraise "rails-5" do
- gem "rails", "~> 5.0.0"
+appraise "rails-5.0" do
+  gem "rails", "~> 5.0.0"
+  gem "sprockets", "~> 3.7"
 end
 
 appraise "rails-5.1" do
- gem "rails", "~> 5.1.0"
+  gem "rails", "~> 5.1.0"
+  gem "sprockets", "~> 3.7"
 end
 
 appraise "rails-5.2" do
- gem "rails", "~> 5.2.0"
+  gem "rails", "~> 5.2.0"
 end
 
 appraise "rails-6.0" do
- gem "rails", "~> 6.0.3"
+  gem "rails", "~> 6.0.3"
 end
 
 appraise "rails-6.1" do
   gem "rails", "~> 6.1.3"
- end
+end
+
+appraise "rails-edge" do
+  gem "rails", github: 'rails/rails'
+end

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem "sprockets", "3.7.2"
+gem "sprockets", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.1.0"
-gem "sprockets", "~> 3.7"
+gem "rails", github: "rails/rails"
 
 gemspec path: "../"


### PR DESCRIPTION
Improve Travis CI build

- Fix Travis CI config warnings (build and distro entries)
- Test on Focal Fossa
- Sort Rails versions by descending order (newest first)
- Rename rails_5 gemfile to include .0
- Cache bundled dependencies
- Enable Fast Finish
- Do not test Rails 5.x against Ruby 3.0 stable
- Test Rails 5.0 and 5.1 with Sprockets 3