### PR TITLE
Support old Rubies pre 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## Unreleased
+## 3.5.0 (May 2022)
 
-- Restored legacy templates for Rails < 7
-- Updated Appraisals to supported Rails versions
-- Replace Travis CI with Github Actions.
+* Restored legacy templates for Rails < 7
+* Updated Appraisals to supported Rails versions
+* Replace Travis CI with Github Actions.
+
+Thanks https://github.com/davidwessman (#180)
+
 
 ## 3.4.0 (March 2022)
 

--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -13,21 +13,23 @@ module Slim
 
         ActiveSupport.on_load(:action_view) do
           ActiveSupport.on_load(:after_initialize) do
-            if defined?(CacheDigests::DependencyTracker)
-              # 'cache_digests' gem being used (overrides Rails 4 implementation)
-              CacheDigests::DependencyTracker.register_tracker :slim, CacheDigests::DependencyTracker::ERBTracker
+            begin # rubocop:disable Style/RedundantBegin
+              if defined?(CacheDigests::DependencyTracker)
+                # 'cache_digests' gem being used (overrides Rails 4 implementation)
+                CacheDigests::DependencyTracker.register_tracker :slim, CacheDigests::DependencyTracker::ERBTracker
 
-              if ::Rails.env.development?
-                # recalculate cache digest keys for each request
-                CacheDigests::TemplateDigestor.cache = ActiveSupport::Cache::NullStore.new
+                if ::Rails.env.development?
+                  # recalculate cache digest keys for each request
+                  CacheDigests::TemplateDigestor.cache = ActiveSupport::Cache::NullStore.new
+                end
+              elsif ::Rails.version.to_s >= "4.0"
+                # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
+                require "action_view/dependency_tracker"
+                ActionView::DependencyTracker.register_tracker :slim, ActionView::DependencyTracker::ERBTracker
               end
-            elsif ::Rails.version.to_s >= "4.0"
-              # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
-              require "action_view/dependency_tracker"
-              ActionView::DependencyTracker.register_tracker :slim, ActionView::DependencyTracker::ERBTracker
+            rescue
+              # likely this version of Rails doesn't support dependency tracking
             end
-          rescue
-            # likely this version of Rails doesn't support dependency tracking
           end
         end
       end

--- a/lib/slim-rails/version.rb
+++ b/lib/slim-rails/version.rb
@@ -1,5 +1,5 @@
 module Slim
   module Rails
-    VERSION = "3.4.0"
+    VERSION = "3.5.0"
   end
 end


### PR DESCRIPTION
`do ... end` blocks are implicit `begin ... end` blocks since Ruby 2.5.
This code was introduced recently in f6be8fcaa3db6b4f1f6536dc2770644f19923716 in an attempt to set up more modern CI but at the same time it made the gem incompatible with Ruby versions older than 2.5

This PR will `rubocop:disable Style/RedundantBegin` and restore old style code.