### PR TITLE
Support Slim 5

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "actionpack", [">= 3.1"]
   spec.add_runtime_dependency "railties", [">= 3.1"]
-  spec.add_runtime_dependency "slim", [">= 3.0", "< 5.0"]
+  spec.add_runtime_dependency "slim", [">= 3.0", "< 6.0"]
 
   spec.add_development_dependency "sprockets-rails"
   spec.add_development_dependency "slim_lint", "~> 0.21.0"


### PR DESCRIPTION
This commit changes the dependency to the `slim` gem to allow using its version 5.0, that was [released on the 23rd of January 2022][0]

[0]: https://rubygems.org/gems/slim/versions/5.0.0