### PR TITLE
Adds Ruby 3.2 to the CI matrix. Quotes 3.0 to avoid truncation. Upgrades checkout action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, '3.0', 3.1]
         rails: ['6.0', '6.1', '7.0']
         include:
           - ruby: 2.6
             rails: '5.2'
+          - ruby: 3.2
+            rails: '7.0'
 
     name: Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }}
     env:
@@ -24,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This runs green on my fork.

Quoting '3.0' is necessary to avoid truncation to '3'.  Currently Ruby 3.2.0 is being loaded for the '3.0' entries because of this truncation.  That's not the intended behavior.