### PR TITLE
Fix the failed Slim 5.0.0 release

### DIFF
--- a/lib/slim-rails/version.rb
+++ b/lib/slim-rails/version.rb
@@ -1,5 +1,5 @@
 module Slim
   module Rails
-    VERSION = "3.5.1"
+    VERSION = "3.6.0"
   end
 end

--- a/lib/slim-rails/version.rb
+++ b/lib/slim-rails/version.rb
@@ -1,5 +1,5 @@
 module Slim
   module Rails
-    VERSION = "3.6.0"
+    VERSION = "3.6.1"
   end
 end

--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "actionpack", [">= 3.1"]
   spec.add_runtime_dependency "railties", [">= 3.1"]
-  spec.add_runtime_dependency "slim", [">= 3.0", "< 6.0"]
+  spec.add_runtime_dependency "slim", [">= 3.0", "!= 5.0.0", "< 6.0"]
 
   spec.add_development_dependency "sprockets-rails"
   spec.add_development_dependency "slim_lint", "~> 0.21.0"


### PR DESCRIPTION
This blocks Slim version 5.0.0 which has issues with setting up the class/module namespace properly with Rails