### PR TITLE
README: Separate out details from main things

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Every time you generate a controller or scaffold, you'll get Slim templates.
 
 If you have existing `.erb` templates, check out our guide [How to convert your `.erb` templates to `.slim`](https://github.com/slim-template/slim/wiki/Template-Converters-ERB-to-SLIM) on how to achieve this.
 
-This gem is tested with Ruby on Rails 5.2+.
+This gem is [tested with Ruby on Rails 5.2+](/.github/workflows/main.yml).
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # slim-rails [![Gem Version](https://img.shields.io/gem/v/slim-rails.svg)](http://rubygems.org/gems/slim-rails) [![Build Status](https://github.com/slim-template/slim-rails/actions/workflows/main.yml/badge.svg)](https://github.com/slim-template/slim-rails/actions/workflows/main.yml) [![Code Climate](https://codeclimate.com/github/slim-template/slim-rails/badges/gpa.svg)](https://codeclimate.com/github/slim-template/slim-rails)
 
-slim-rails provides Slim generators for Rails 3+. It was based on
-[haml-rails](http://github.com/indirect/haml-rails) and it does basically the
-same:
+slim-rails provides Slim generators for Rails:
 
 * Any time you generate a controller or scaffold, you'll get Slim templates
   (instead of ERB)
@@ -18,8 +16,14 @@ gem "slim-rails"
 
 And that's it.
 
-If you have existing `.erb` templates, check out [our guide](https://github.com/slim-template/slim/wiki/Template-Converters-ERB-to-SLIM) on how to achieve this.
+Every time you generate a controller or scaffold, you'll get Slim templates.
+
+If you have existing `.erb` templates, check out our guide [How to convert your `.erb` templates to `.slim`](https://github.com/slim-template/slim/wiki/Template-Converters-ERB-to-SLIM) on how to achieve this.
+
+This gem is tested with Ruby on Rails 5.2+.
+
+## History
+
+`slim-rails` was based on [haml-rails](https://github.com/haml/haml-rails) and it does basically the same thing.
 
 From the version 0.2.0, there is no need to include gem "slim" in your Gemfile.
-
-Every time you generate a controller or scaffold, you'll get Slim templates.


### PR DESCRIPTION
- Add a History section for notes about the past.
- Update link to indirect's haml repo to the current link of that repo, now using https://.
- Make the guide's link text more descriptive.
- Do not promise Rails 3+ support, but note what the earliest-tested Rails version in the testing matrix is, instead.