### PR TITLE
Fix ActionView::SyntaxErrorInTemplate when scaffolding with namespace

### DIFF
--- a/lib/generators/slim/scaffold/templates/_form.html.slim.tt
+++ b/lib/generators/slim/scaffold/templates/_form.html.slim.tt
@@ -1,9 +1,9 @@
-= form_with(model: @<%= model_resource_name %>) do |form|
-  - if @<%= singular_table_name %>.errors.any?
+= form_with(model: <%= model_resource_name %>) do |form|
+  - if <%= singular_table_name %>.errors.any?
     div style="color: red"
-      h2 = "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:"
+      h2 = "#{pluralize(<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:"
       ul
-        - @<%= singular_table_name %>.errors.each do |error|
+        - <%= singular_table_name %>.errors.each do |error|
           li = error.full_message
 
 <% attributes.each do |attribute| -%>


### PR DESCRIPTION
It fixed ActionView::SyntaxErrorInTemplate when scaffolding with namespace.
It is same format with rails v7.x.
https://github.com/rails/rails/blob/v7.0.6/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt#L1-L12

fixed #192 
