### PR TITLE
CI: Update slim_lint version to fix `rexml/document (LoadError)`

### DIFF
--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "slim", [">= 3.0", "!= 5.0.0", "< 6.0"]
 
   spec.add_development_dependency "sprockets-rails"
-  spec.add_development_dependency "slim_lint", "~> 0.24.0"
+  spec.add_development_dependency "slim_lint", ">= 0.24.0"
   spec.add_development_dependency "rocco"
   spec.add_development_dependency "redcarpet"
   spec.add_development_dependency "awesome_print"


### PR DESCRIPTION
This Pull Request has been created because CI raises the error of `rexml/document (LoadError)` with ruby 3.0 or higher.

For CI error details, see the following:
```sh
# CI: Ruby 3.3 - Rails 7.2
$ bundle exec rake
...
/opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': cannot load such file -- rexml/document (LoadError)
	from /opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/runner/work/slim-rails/slim-rails/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /home/runner/work/slim-rails/slim-rails/vendor/bundle/ruby/3.3.0/gems/slim_lint-0.24.0/lib/slim_lint/reporter/checkstyle_reporter.rb:3:in `<top (required)>'
...
```
https://github.com/taketo1113/slim-rails/actions/runs/11685319779/job/32538807815


This Pull Request changes to update slim_lint gem version of v0.29.0 or higher to fix `rexml/document (LoadError)`.
slim_lint v0.29.0 has added a dependency on rexml because RuboCop v1.66.0 dropped its dependency on rexml.
https://github.com/sds/slim-lint/pull/184
