### PR TITLE
Add Rails 8.0 & Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, '3.0', 3.1, 3.2, 3.3]
-        rails: ['6.0', '6.1', '7.0', '7.1', '7.2']
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, 3.4]
+        rails: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0']
         include:
           - ruby: 2.6
             rails: '5.2'
         exclude:
+          # rails 8.0: support ruby 3.2+
+          - ruby: 2.7
+            rails: '8.0'
+          - ruby: 3.0
+            rails: '8.0'
+          - ruby: 3.1
+            rails: '8.0'
           # rails 7.2: support ruby 3.1+
           - ruby: 2.7
             rails: '7.2'

--- a/Appraisals
+++ b/Appraisals
@@ -4,14 +4,32 @@ end
 
 appraise "rails-6.0" do
   gem "rails", "~> 6.0.4"
+
+  # for ruby 3.4+
+  gem "base64"
+  gem "bigdecimal"
+  gem "mutex_m"
+  gem "drb"
 end
 
 appraise "rails-6.1" do
   gem "rails", "~> 6.1.5"
+
+  # for ruby 3.4+
+  gem "base64"
+  gem "bigdecimal"
+  gem "mutex_m"
+  gem "drb"
 end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0.2"
+
+  # for ruby 3.4+
+  gem "base64"
+  gem "bigdecimal"
+  gem "mutex_m"
+  gem "drb"
 end
 
 appraise "rails-7.1" do
@@ -20,6 +38,10 @@ end
 
 appraise "rails-7.2" do
   gem "rails", "~> 7.2.0"
+end
+
+appraise "rails-8.0" do
+  gem "rails", "~> 8.0.0"
 end
 
 appraise "rails-edge" do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,5 +3,9 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.5"
+gem "base64"
+gem "bigdecimal"
+gem "mutex_m"
+gem "drb"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,5 +3,9 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.2"
+gem "base64"
+gem "bigdecimal"
+gem "mutex_m"
+gem "drb"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,10 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.4"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
-gem "drb"
+gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "slim", [">= 3.0", "!= 5.0.0", "< 6.0"]
 
   spec.add_development_dependency "sprockets-rails"
-  spec.add_development_dependency "slim_lint", "~> 0.24.0"
+  spec.add_development_dependency "slim_lint", ">= 0.24.0"
   spec.add_development_dependency "rocco"
   spec.add_development_dependency "redcarpet"
   spec.add_development_dependency "awesome_print"


### PR DESCRIPTION
This Pull Request updates the CI matrix for Rails 8.0 / Ruby 3.4.
It also adds dependencies for gems that became part of `bundled gems` in Ruby 3.4 for Rails 7.0 and earlier to the Appraisals file.

### Additional Information

To address CI errors occurring in Ruby 3.0 or higher, this Pull Request includes updates to `development_dependency` from the following Pull Request:

- #198

