### PR TITLE
Support Rails 8.0 authentication generator

### DIFF
--- a/lib/generators/slim/authentication/authentication_generator.rb
+++ b/lib/generators/slim/authentication/authentication_generator.rb
@@ -1,0 +1,21 @@
+require "rails/generators/erb/authentication/authentication_generator"
+
+module Slim
+  module Generators
+    class AuthenticationGenerator < Erb::Generators::AuthenticationGenerator
+      source_root File.expand_path(File.join("..", "templates"), __FILE__)
+
+      def create_files
+        template "sessions/new.html.slim", "app/views/sessions/new.html.slim"
+        template "passwords/new.html.slim", "app/views/passwords/new.html.slim"
+        template "passwords/edit.html.slim", "app/views/passwords/edit.html.slim"
+      end
+
+      protected
+
+      def handler
+        :slim
+      end
+    end
+  end
+end

--- a/lib/generators/slim/authentication/templates/passwords/edit.html.slim
+++ b/lib/generators/slim/authentication/templates/passwords/edit.html.slim
@@ -1,0 +1,10 @@
+h1 Update your password
+
+= tag.div(flash[:alert], style: "color:red") if flash[:alert]
+
+= form_with url: password_path(params[:token]), method: :put do |form|
+  = form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72
+  br
+  = form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72
+  br
+  = form.submit "Save"

--- a/lib/generators/slim/authentication/templates/passwords/new.html.slim
+++ b/lib/generators/slim/authentication/templates/passwords/new.html.slim
@@ -1,0 +1,8 @@
+h1 Forgot your password?
+
+= tag.div(flash[:alert], style: "color:red") if flash[:alert]
+
+= form_with url: passwords_path do |form|
+  = form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address]
+  br
+  = form.submit "Email reset instructions"

--- a/lib/generators/slim/authentication/templates/sessions/new.html.slim
+++ b/lib/generators/slim/authentication/templates/sessions/new.html.slim
@@ -1,0 +1,12 @@
+= tag.div(flash[:alert], style: "color:red") if flash[:alert]
+= tag.div(flash[:notice], style: "color:green") if flash[:notice]
+
+= form_with url: session_path do |form|
+  = form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address]
+  br
+  = form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72
+  br
+  = form.submit "Sign in"
+br
+
+= link_to "Forgot password?", new_password_path

--- a/test/fixtures/application_controller.rb
+++ b/test/fixtures/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/test/lib/generators/slim/authentication_generator_test.rb
+++ b/test/lib/generators/slim/authentication_generator_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require "lib/generators/slim/testing_helper"
+
+if ::Rails::VERSION::MAJOR >= 8
+  class Slim::Generators::AuthenticationGeneratorTest < Rails::Generators::TestCase
+    include SlimLintHelpers
+
+    destination File.join(Rails.root)
+    tests Rails::Generators::AuthenticationGenerator
+    arguments %w[--template-engine slim]
+
+    setup :prepare_destination
+    setup :copy_routes
+    setup :copy_application_controller
+
+    test "should invoke template engine" do
+      run_generator_instance
+
+      assert_file File.join("app", "views", "sessions", "new.html.slim")
+      assert_file File.join("app", "views", "passwords", "new.html.slim")
+      assert_file File.join("app", "views", "passwords", "edit.html.slim")
+    end
+
+    test "should generate SlimLint valid templates" do
+      run_generator_instance
+
+      templates = Dir[File.join(Rails.root, "app", "views", "**", "*.slim")]
+      assert_empty lint(templates)
+    end
+
+    private
+
+    def run_generator_instance
+      commands = []
+      command_stub ||= ->(command, *args) { commands << [command, *args] }
+
+      content = nil
+      generator.stub(:execute_command, command_stub) do
+        content = capture(:stdout) do
+          generator.invoke_all
+        end
+      end
+
+      content
+    end
+  end
+end

--- a/test/lib/generators/slim/testing_helper.rb
+++ b/test/lib/generators/slim/testing_helper.rb
@@ -8,4 +8,8 @@ module SlimLintHelpers
   end
 end
 
-require_generators slim: ["scaffold", "controller", "mailer"]
+if ::Rails::VERSION::MAJOR >= 8
+  require_generators slim: ["scaffold", "controller", "mailer", "authentication"]
+else
+  require_generators slim: ["scaffold", "controller", "mailer"]
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,16 +29,30 @@ def copy_routes
   FileUtils.cp File.expand_path(routes), destination
 end
 
+def copy_application_controller
+  app_controller = File.expand_path(File.join(File.dirname(__FILE__), "fixtures", "application_controller.rb"))
+  destination = File.join(Rails.root, "app", "controllers")
+  FileUtils.mkdir_p(destination)
+  FileUtils.cp File.expand_path(app_controller), destination
+end
+
 def assert_class(klass, content)
   assert content =~ /class #{klass}(\(.+\))?(.*?)\nend/m, "Expected to have class #{klass}"
   yield $2.strip if block_given?
 end
 
 def generator_list
-  {
-    rails: ["scaffold", "controller", "mailer"],
-    slim: ["scaffold", "controller", "mailer"]
-  }
+  if ::Rails::VERSION::MAJOR >= 8
+    {
+      rails: ["scaffold", "controller", "mailer", "authentication"],
+      slim: ["scaffold", "controller", "mailer", "authentication"]
+    }
+  else
+    {
+      rails: ["scaffold", "controller", "mailer"],
+      slim: ["scaffold", "controller", "mailer"]
+    }
+  end
 end
 
 def path_prefix(name)


### PR DESCRIPTION
This Pull Request adds support for the Rails 8.0 authentication generator.

The `Slim::Generators::AuthenticationGenerator` is added to generate the following slim files when running `rails generator authentication`:

- app/views/sessions/new.html.slim
- app/views/passwords/new.html.slim
- app/views/passwords/edit.html.slim

The contents of the generated slim files are equivalent to the ERB files used in the authentication generator templates from the `rails/rails` repository.

- https://github.com/rails/rails/tree/v8.0.1/railties/lib/rails/generators/erb/authentication/templates/app/views

### Additional Information

Since the authentication generator is a feature introduced in Rails 8.0, the `AuthenticationGenerator` tests are skipped when running `slim-rails` tests on Rails versions below 8.0.

- https://github.com/rails/rails/pull/52442

Additionally, to avoid errors caused by calling `execute_command` during the execution of `Rails::Generators::AuthenticationGenerator`, `execute_command` is stubbed to bypass the error.

- https://github.com/rails/rails/blob/v8.0.1/railties/lib/rails/generators/rails/authentication/authentication_generator.rb#L41-L48
