### PR TITLE
Drop sprockets-rails dev dependency as Rails 8.0 defaults to propshaft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,13 @@ jobs:
         include:
           - ruby: 2.6
             rails: '5.2'
+          # rails 8.0 + sprockets-rails
+          - ruby: 3.2
+            rails: '8.0_sprockets'
+          - ruby: 3.3
+            rails: '8.0_sprockets'
+          - ruby: 3.4
+            rails: '8.0_sprockets'
         exclude:
           # rails 8.0: support ruby 3.2+
           - ruby: 2.7

--- a/Appraisals
+++ b/Appraisals
@@ -10,6 +10,9 @@ appraise "rails-6.0" do
   gem "bigdecimal"
   gem "mutex_m"
   gem "drb"
+
+  # Fix https://github.com/rails/rails/issues/54260
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise "rails-6.1" do
@@ -20,6 +23,9 @@ appraise "rails-6.1" do
   gem "bigdecimal"
   gem "mutex_m"
   gem "drb"
+
+  # Fix https://github.com/rails/rails/issues/54260
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise "rails-7.0" do
@@ -30,6 +36,9 @@ appraise "rails-7.0" do
   gem "bigdecimal"
   gem "mutex_m"
   gem "drb"
+
+  # Fix https://github.com/rails/rails/issues/54260
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise "rails-7.1" do

--- a/Appraisals
+++ b/Appraisals
@@ -30,6 +30,7 @@ end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0.2"
+  gem "sprockets-rails"
 
   # for ruby 3.4+
   gem "base64"
@@ -43,16 +44,25 @@ end
 
 appraise "rails-7.1" do
   gem "rails", "~> 7.1.0"
+  gem "sprockets-rails"
 end
 
 appraise "rails-7.2" do
   gem "rails", "~> 7.2.0"
+  gem "sprockets-rails"
 end
 
 appraise "rails-8.0" do
   gem "rails", "~> 8.0.0"
+  gem "propshaft"
+end
+
+appraise "rails-8.0-sprockets" do
+  gem "rails", "~> 8.0.0"
+  gem "sprockets-rails"
 end
 
 appraise "rails-edge" do
   gem "rails", github: "rails/rails", branch: "main"
+  gem "sprockets-rails"
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -7,5 +7,6 @@ gem "base64"
 gem "bigdecimal"
 gem "mutex_m"
 gem "drb"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,5 +7,6 @@ gem "base64"
 gem "bigdecimal"
 gem "mutex_m"
 gem "drb"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,5 +7,6 @@ gem "base64"
 gem "bigdecimal"
 gem "mutex_m"
 gem "drb"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.2"
+gem "sprockets-rails"
 gem "base64"
 gem "bigdecimal"
 gem "mutex_m"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.2.0"
+gem "sprockets-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 8.0.0"
+gem "propshaft"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0_sprockets.gemfile
+++ b/gemfiles/rails_8.0_sprockets.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.1.0"
+gem "rails", "~> 8.0.0"
 gem "sprockets-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
+gem "sprockets-rails"
 
 gemspec path: "../"

--- a/slim-rails.gemspec
+++ b/slim-rails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "railties", [">= 3.1"]
   spec.add_runtime_dependency "slim", [">= 3.0", "!= 5.0.0", "< 6.0"]
 
-  spec.add_development_dependency "sprockets-rails"
   spec.add_development_dependency "slim_lint", ">= 0.24.0"
   spec.add_development_dependency "rocco"
   spec.add_development_dependency "redcarpet"


### PR DESCRIPTION
This Pull Request removes `sprockets-rails` from the `development_dependency` of slim-rails, since Rails 8.0 now defaults to `propshaft`.

Along with this change, tests that depend on Sprockets will only run when `sprockets-rails` is present in the dependencies.
If `sprockets-rails` is not included, those tests will be skipped.
Note that this change does not affect the behavior of the `slim-rails` gem itself. `slim-rails` continues to work without `sprockets-rails`, just as before.

In addition, the gemfiles used in CI have been updated to include the default dependencies (`propshaft` or `sprockets-rails`) for each Rails version.
For Rails 8.0, an additional gemfile with `sprockets-rails` has been added so that tests also run with the Rails 8.0 + Sprockets combination.


### Additional Information
#### Replacing Sprockets with Propshaft
Starting with Rails 8.0, the default asset pipeline in generated by `rails new` has been changed from `sprockets-rails` to `propshaft`.

Below is the relevant Gemfile diff between `rails new` with Rails 8.0 and Rails 7.2:

```diff
# Gemfile
source "https://rubygems.org"

# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+gem "rails", "~> 8.0.0"
+# The modern asset pipeline for Rails [https://github.com/rails/propshaft]
+gem "propshaft"
-gem "rails", "~> 7.2.0"
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
# Use sqlite3 as the database for Active Record
+gem "sqlite3", ">= 2.1"
-gem "sqlite3", ">= 1.4"
...
```

Reference: Replacing Sprockets with Propshaft | Ruby on Rails — Rails 8.0: No PaaS Required
https://rubyonrails.org/2024/11/7/rails-8-no-paas-required#replacing-sprockets-with-propshaft

#### CI: Fix NameError of uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
CI on the master branch had been failing with the following error:
```
/home/runner/work/slim-rails/slim-rails/vendor/bundle/ruby/3.4.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in '<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
    ^^^^^^
	from /home/runner/work/slim-rails/slim-rails/vendor/bundle/ruby/3.4.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in '<module:ActiveSupport>'
...
```

To address this, `concurrent-ruby` v1.3.4 has been added for compatibility with Rails versions <= 7.0.
This resolves an error that occurs with Rails <= 7.0 and `concurrent-ruby` v1.3.5:

- https://github.com/rails/rails/issues/54260
