### PR TITLE
CHANGELOG: Add 3.6.2, 3.6.3, 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.7.0 (December 29, 2024)
+
+- Support Rails 8.0 authentication generator ([#201])
+- Update CI matrix for Rails 7.2 / 8.0 and Ruby 3.3 / 3.4 ([#197], [#200])
+
+## 3.6.3 (October 24, 2023)
+
+- Fix ActionView::SyntaxErrorInTemplate when scaffolding with namespace ([#193])
+- Update CI matrix for Rails 7.1 ([#194])
+
+## 3.6.2 (March 9, 2023)
+
+- Update gemspec to be compatible with slim 5.1 ([#191])
+- README: Separate out details from main things ([#190])
+
 ## 3.6.1 (February 14, 2023)
 
 - Fix to avoid depending on the failed Slim 5.0.0 release ([#188])

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# slim-rails [![Gem Version](https://img.shields.io/gem/v/slim-rails.svg)](http://rubygems.org/gems/slim-rails) [![Build Status](https://github.com/slim-template/slim-rails/actions/workflows/main.yml/badge.svg)](https://github.com/slim-template/slim-rails/actions/workflows/main.yml) [![Code Climate](https://codeclimate.com/github/slim-template/slim-rails/badges/gpa.svg)](https://codeclimate.com/github/slim-template/slim-rails)
+# slim-rails [![Gem Version](https://img.shields.io/gem/v/slim-rails.svg)](http://rubygems.org/gems/slim-rails) [![Build Status](https://github.com/slim-template/slim-rails/actions/workflows/main.yml/badge.svg)](https://github.com/slim-template/slim-rails/actions/workflows/main.yml)
 
 slim-rails provides Slim generators for Rails:
 


### PR DESCRIPTION
This Pull Request updates the CHANGELOG to include the changes made since v3.6.2.

Additionally, it removes the Code Climate badge from the README because the badge is broken.
