### PR TITLE
`rails notes` raises Encoding::UndefinedConversionError with non-ASCII characters on Ruby 3.4

### DIFF
--- a/lib/slim-rails.rb
+++ b/lib/slim-rails.rb
@@ -51,7 +51,24 @@ module Slim
         end
 
         annotation_class.register_extensions("slim") do |tag|
-          /\s*\/\s*(#{tag}):?\s*(.*)$/
+          Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(#{tag}):?\s*(.*)$/)
+        end
+      end
+    end
+
+    class AnnotationExtractor
+      def initialize(pattern)
+        @pattern = pattern
+      end
+
+      def annotations(file)
+        lineno = 0
+        # Use UTF-8 encoding with fallback for invalid/undefined bytes
+        File.readlines(file, encoding: Encoding::UTF_8, invalid: :replace, undef: :replace).filter_map do |line|
+          lineno += 1
+          if line =~ @pattern
+            ::Rails::SourceAnnotationExtractor::Annotation.new(lineno, $1, $2)
+          end
         end
       end
     end

--- a/test/lib/slim-rails_annotation_extractor_test.rb
+++ b/test/lib/slim-rails_annotation_extractor_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+require "tmpdir"
+
+class Slim::Rails::AnnotationExtractorTest < ActiveSupport::TestCase
+  def create_temp_file(content)
+    file = Tempfile.new(["test", ".slim"])
+    file.write(content)
+    file.close
+    file
+  end
+
+  test "extracts TODO annotation from slim file" do
+    file = create_temp_file("/ TODO: Fix this later\nh1 Hello")
+    extractor = Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(TODO):?\s*(.*)$/)
+
+    annotations = extractor.annotations(file.path)
+
+    assert_equal 1, annotations.size
+    assert_equal 1, annotations.first.line
+    assert_equal "TODO", annotations.first.tag
+    assert_equal "Fix this later", annotations.first.text
+  ensure
+    file.unlink
+  end
+
+  test "extracts multiple annotations from slim file" do
+    content = <<~SLIM
+      / TODO: First task
+      h1 Title
+      / FIXME: Something broken
+      p Content
+    SLIM
+    file = create_temp_file(content)
+    extractor = Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(TODO|FIXME):?\s*(.*)$/)
+
+    annotations = extractor.annotations(file.path)
+
+    assert_equal 2, annotations.size
+    assert_equal 1, annotations.first.line
+    assert_equal "TODO", annotations.first.tag
+    assert_equal 3, annotations.last.line
+    assert_equal "FIXME", annotations.last.tag
+  ensure
+    file.unlink
+  end
+
+  test "returns empty array when no annotations found" do
+    file = create_temp_file("h1 Hello\np World")
+    extractor = Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(TODO):?\s*(.*)$/)
+
+    annotations = extractor.annotations(file.path)
+
+    assert_equal [], annotations
+  ensure
+    file.unlink
+  end
+
+  test "handles Japanese characters without encoding error" do
+    content = <<~SLIM
+      / TODO: 日本語のタスク
+      h1 こんにちは
+      p 世界
+    SLIM
+    file = create_temp_file(content)
+    extractor = Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(TODO):?\s*(.*)$/)
+
+    annotations = extractor.annotations(file.path)
+
+    assert_equal 1, annotations.size
+    assert_equal "TODO", annotations.first.tag
+    assert_equal "日本語のタスク", annotations.first.text
+  ensure
+    file.unlink
+  end
+
+  test "handles mixed encoding content gracefully" do
+    # Create file with potentially problematic encoding
+    file = Tempfile.new(["test", ".slim"], encoding: "ASCII-8BIT")
+    file.write("/ TODO: Test task\nh1 Hello".force_encoding("ASCII-8BIT"))
+    file.close
+
+    extractor = Slim::Rails::AnnotationExtractor.new(/\s*\/\s*(TODO):?\s*(.*)$/)
+
+    # Should not raise Encoding::UndefinedConversionError
+    annotations = extractor.annotations(file.path)
+
+    assert_equal 1, annotations.size
+  ensure
+    file.unlink
+  end
+end


### PR DESCRIPTION
## Summary

Since slim-rails 4.0.0 added support for Rails Annotations (PR #206), `rails notes` raises `Encoding::UndefinedConversionError` when slim files contain non-ASCII characters (e.g., Japanese) in TODO/FIXME comments, when running on Ruby 3.4 in a PTY environment.

## Steps to reproduce

1. Use Ruby 3.4.x and Rails 8.0.x
2. Install slim-rails 4.0.0
3. Create a slim file with non-ASCII characters in annotations:
   ```slim
   / TODO: データベースの最適化を行う
   div
     p Hello
   ```
4. Run `rails notes` directly in a terminal emulator (iTerm2, WezTerm, Terminal.app, etc.)

## Expected behavior

The command should output annotations normally, including non-ASCII characters:

```
app/views/example.html.slim:
  * [   1] [TODO] データベースの最適化を行う
```

## Actual behavior

```
/path/to/gems/railties-8.0.4/lib/rails/source_annotation_extractor.rb:208:in 'IO#write': "\xE3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
```

## Workaround

```bash
bundle exec rails notes | cat
```

## Environment

- Ruby version: 3.4.7
- Rails version: 8.0.4
- slim-rails version: 4.0.0
- OS: macOS
- Terminal: iTerm2, WezTerm (both reproduce the issue)

## Root cause analysis

### How slim-rails registers annotations (lib/slim-rails.rb lines 53-55)

```ruby
annotation_class.register_extensions("slim") do |tag|
  /\s*\/\s*(#{tag}):?\s*(.*)$/
end
```

This returns a `Regexp`, which Rails wraps in `PatternExtractor` (source_annotation_extractor.rb lines 189-190):

```ruby
pattern = PatternExtractor.new(pattern) if pattern.is_a?(Regexp)
```

### How PatternExtractor works

```ruby
class PatternExtractor < Struct.new(:pattern)
  def annotations(file)
    File.readlines(file, encoding: Encoding::BINARY).inject([]) do |list, line|
      # ...
    end
  end
end
```

Files are read with `Encoding::BINARY` (ASCII-8BIT), and the annotation text retains this encoding.

### Why the error occurs on Ruby 3.4

1. Slim files are read with `Encoding::BINARY`
2. Non-ASCII characters (UTF-8 bytes like `\xE3`) are stored as ASCII-8BIT
3. Ruby 3.4 is stricter about encoding conversions when outputting to PTY
4. `Encoding::UndefinedConversionError` is raised

### Why `.rb` files don't have this issue

`.rb` files use `ParserExtractor` with **Prism** (in Ruby 3.4), which handles encoding properly.
